### PR TITLE
ラベル新規作成時に編集用のstateを参照していたため修正した see #261

### DIFF
--- a/store/pages/labels/new/actions.ts
+++ b/store/pages/labels/new/actions.ts
@@ -1,5 +1,5 @@
 export function usePageDrinkLabelNewActions () {
-  const { name, color, standardAmount } = usePageDrinkLabelEditState()
+  const { name, color, standardAmount } = usePageDrinkLabelNewState()
   const { $i18n } = useNuxtApp()
   const localePath = useLocalePath()
 


### PR DESCRIPTION
fixed #261 