### PR TITLE
fix: make release workflow find PR reliably

### DIFF
--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -21,13 +21,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # マージコミットに関連するPRを取得
-          if ! PR_NUMBER=$(gh api /repos/${{ github.repository }}/commits/${{ github.sha }}/pulls --jq '.[0].number' 2>&1); then
-            echo "::error::Failed to fetch PR number: $PR_NUMBER"
-            echo "version_type=" >> $GITHUB_OUTPUT
-            exit 0
+          # マージコミットに関連するPRを取得（REST APIはプレビューAcceptヘッダーが必要）
+          PR_NUMBER=$(gh api \
+            -H "Accept: application/vnd.github.groot-preview+json" \
+            /repos/${{ github.repository }}/commits/${{ github.sha }}/pulls --jq '.[0].number' 2>/dev/null || true)
+
+          # プレビューAPIで取得できない場合はコミットメッセージからPR番号を推測（squash merge対策）
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
+            COMMIT_MESSAGE=$(git log -1 --pretty=%B)
+            FALLBACK_PR_NUMBER=$(echo "$COMMIT_MESSAGE" | sed -n 's/.*#\([0-9]\+\).*/\1/p' | head -n 1)
+            if [ -n "$FALLBACK_PR_NUMBER" ]; then
+              echo "::notice::Fallback: detected PR #$FALLBACK_PR_NUMBER from commit message"
+              PR_NUMBER=$FALLBACK_PR_NUMBER
+            fi
           fi
-          
+
           if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
             echo "::notice::No PR found for this commit. Skipping version update."
             echo "version_type=" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- add required preview Accept header when resolving PR from commit
- fallback to parse PR number from merge commit message to handle squash merges

## Testing
- not run (workflow change)
