### PR TITLE
Feature/#310 persist activity log

### DIFF
--- a/app/components/domain/activity/molecules/Log.vue
+++ b/app/components/domain/activity/molecules/Log.vue
@@ -56,11 +56,12 @@ const formatTimeAgo = (time: string | null, unit: 'days' | 'hours' | 'minutes' |
   }
 }
 
-const formatActivityType = (type: 'plus' | 'minus', drinkName: string) => {
+const formatActivityType = (type: 'plus' | 'minus', drinkName: string, drinkLabelName: string | null) => {
+  const displayName = drinkLabelName ? `${drinkLabelName}：${drinkName}` : drinkName
   if (type === 'plus') {
-    return t(LOCALE_ACTIVITY_LOG_PLUS, { drinkName })
+    return t(LOCALE_ACTIVITY_LOG_PLUS, { drinkName: displayName })
   }
-  return t(LOCALE_ACTIVITY_LOG_MINUS, { drinkName })
+  return t(LOCALE_ACTIVITY_LOG_MINUS, { drinkName: displayName })
 }
 
 const formatTime = (date: Date) => {
@@ -93,7 +94,7 @@ const formatTime = (date: Date) => {
           >
             <Icon :name="activity.type === 'plus' ? 'mdi:plus-circle' : 'mdi:minus-circle'" />
           </span>
-          <span class="ml-1">{{ formatActivityType(activity.type, activity.drinkName) }}</span>
+          <span class="ml-1">{{ formatActivityType(activity.type, activity.drinkName, activity.drinkLabelName) }}</span>
         </div>
       </template>
       <template v-else>

--- a/app/components/domain/activity/molecules/Log.vue
+++ b/app/components/domain/activity/molecules/Log.vue
@@ -30,13 +30,27 @@ import {
   LOCALE_ACTIVITY_LOG_NO_ACTIVITY,
 } from '~/utils/locales'
 
+interface Props {
+  date: string
+}
+
+const props = defineProps<Props>()
+
 const { t } = useI18n()
 
 const activityLogStore = useActivityLogStore()
-const { latestActivity, allActivities, timeSinceLastActivity, timeSinceLastActivityUnit, hasRecentActivities } = storeToRefs(activityLogStore)
+const { activitiesByDate, latestActivity, timeSinceLastActivity, timeSinceLastActivityUnit } = storeToRefs(activityLogStore)
 
 onMounted(() => {
   activityLogStore.initializeActivityLog()
+})
+
+const currentDateActivities = computed(() => {
+  return activitiesByDate.value(props.date)
+})
+
+const hasActivitiesForDate = computed(() => {
+  return currentDateActivities.value.length > 0
 })
 
 const formatTimeAgo = (time: string | null, unit: 'days' | 'hours' | 'minutes' | null) => {
@@ -81,9 +95,9 @@ const formatTime = (date: Date) => {
       </span>
     </summary>
     <div class="activity-log-content mt-2">
-      <template v-if="hasRecentActivities">
+      <template v-if="hasActivitiesForDate">
         <div
-          v-for="activity in allActivities"
+          v-for="activity in currentDateActivities"
           :key="activity.id"
           class="activity-log-item is-size-7 py-1"
         >

--- a/app/components/domain/activity/molecules/Log.vue
+++ b/app/components/domain/activity/molecules/Log.vue
@@ -6,7 +6,8 @@
 - 折りたたみ可能な履歴リスト（details/summary要素を使用）
 - 最終更新からの経過時間を表示（分/時間/日）
 - 各操作のタイムスタンプとアイコン（+/-）を表示
-- 3日間のログ保持、最大100件まで表示
+- 7日間のログ保持、最大100件まで表示
+- ローカルストレージに永続化し、アクセス時に期限切れを削除
 
 ## State
 - useActivityLogStore から以下を取得:
@@ -33,6 +34,10 @@ const { t } = useI18n()
 
 const activityLogStore = useActivityLogStore()
 const { latestActivity, allActivities, timeSinceLastActivity, timeSinceLastActivityUnit, hasRecentActivities } = storeToRefs(activityLogStore)
+
+onMounted(() => {
+  activityLogStore.initializeActivityLog()
+})
 
 const formatTimeAgo = (time: string | null, unit: 'days' | 'hours' | 'minutes' | null) => {
   if (time === null || unit === null) {

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -102,7 +102,7 @@ watch(date, async () => {
       </template>
     </div>
 
-    <DomainActivityMoleculesLog />
+    <DomainActivityMoleculesLog :date="date" />
 
     <CommonModalMoleculesWarning
       :title="t(LOCALE_INDEX_WARNING_TITLE)"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "title": "飲酒カウンター",
   "description": "飲酒量を家計簿のように記録することで、自分の飲酒傾向を把握して飲酒量や頻度の見直しを図ることを目的としたアプリです。",
   "url": "https://drink-counter-theta.vercel.app",
-  "version": "1.20.6",
+  "version": "1.20.7",
   "license": "MIT",
   "engines": {
     "node": "22"

--- a/store/activityLog/actions.ts
+++ b/store/activityLog/actions.ts
@@ -22,7 +22,7 @@ export function useActivityLogActions () {
   /**
    * Add a new activity log entry
    */
-  const addActivity = (type: 'plus' | 'minus', drinkName: string, drinkLabelName: string | null = null) => {
+  const addActivity = (type: 'plus' | 'minus', drinkName: string, drinkLabelName: string | null = null, date: string = '') => {
     cleanupExpiredEntries()
 
     const entry: ActivityLogEntry = {
@@ -30,6 +30,7 @@ export function useActivityLogActions () {
       type,
       drinkName,
       drinkLabelName,
+      date,
       timestamp: new Date(),
     }
 

--- a/store/activityLog/actions.ts
+++ b/store/activityLog/actions.ts
@@ -21,8 +21,12 @@ export function useActivityLogActions () {
 
   /**
    * Add a new activity log entry
+   * @param type - Operation type: 'plus' or 'minus'
+   * @param drinkName - Name of the drink
+   * @param drinkLabelName - Label name associated with the drink (optional)
+   * @param date - Date of the activity in YYYY-MM-DD format (required)
    */
-  const addActivity = (type: 'plus' | 'minus', drinkName: string, drinkLabelName: string | null = null, date: string = '') => {
+  const addActivity = (type: 'plus' | 'minus', drinkName: string, drinkLabelName: string | null, date: string) => {
     cleanupExpiredEntries()
 
     const entry: ActivityLogEntry = {

--- a/store/activityLog/actions.ts
+++ b/store/activityLog/actions.ts
@@ -46,6 +46,7 @@ export function useActivityLogActions () {
       activityLog.value = activityLog.value.slice(0, getMaxLogEntries())
     }
 
+    // Persist once after all mutations
     persistActivityLog()
   }
 
@@ -59,6 +60,7 @@ export function useActivityLogActions () {
 
   /**
    * Remove expired log entries (older than retention period)
+   * Note: Does not persist automatically - caller should persist after cleanup
    */
   const cleanupExpiredEntries = () => {
     const retentionMs = getLogRetentionDays() * 24 * 60 * 60 * 1000
@@ -66,8 +68,6 @@ export function useActivityLogActions () {
     activityLog.value = activityLog.value.filter(
       entry => now.getTime() - entry.timestamp.getTime() < retentionMs
     )
-
-    persistActivityLog()
   }
 
   return {

--- a/store/activityLog/actions.ts
+++ b/store/activityLog/actions.ts
@@ -22,13 +22,14 @@ export function useActivityLogActions () {
   /**
    * Add a new activity log entry
    */
-  const addActivity = (type: 'plus' | 'minus', drinkName: string) => {
+  const addActivity = (type: 'plus' | 'minus', drinkName: string, drinkLabelName: string | null = null) => {
     cleanupExpiredEntries()
 
     const entry: ActivityLogEntry = {
       id: getNextId(),
       type,
       drinkName,
+      drinkLabelName,
       timestamp: new Date(),
     }
 

--- a/store/activityLog/actions.ts
+++ b/store/activityLog/actions.ts
@@ -1,13 +1,30 @@
 import type { ActivityLogEntry } from './type'
-import { getNextId, getMaxLogEntries, getLogRetentionDays } from './state'
+import {
+  getNextId,
+  getMaxLogEntries,
+  getLogRetentionDays,
+  hydrateActivityLogFromStorage,
+  persistActivityLog,
+} from './state'
 
 export function useActivityLogActions () {
   const { activityLog } = useActivityLogState()
 
   /**
+   * Hydrate from localStorage and cleanup once on entry.
+   */
+  const initializeActivityLog = () => {
+    hydrateActivityLogFromStorage()
+    cleanupExpiredEntries()
+    persistActivityLog()
+  }
+
+  /**
    * Add a new activity log entry
    */
   const addActivity = (type: 'plus' | 'minus', drinkName: string) => {
+    cleanupExpiredEntries()
+
     const entry: ActivityLogEntry = {
       id: getNextId(),
       type,
@@ -22,6 +39,8 @@ export function useActivityLogActions () {
     if (activityLog.value.length > getMaxLogEntries()) {
       activityLog.value = activityLog.value.slice(0, getMaxLogEntries())
     }
+
+    persistActivityLog()
   }
 
   /**
@@ -29,6 +48,7 @@ export function useActivityLogActions () {
    */
   const clearActivityLog = () => {
     activityLog.value = []
+    persistActivityLog()
   }
 
   /**
@@ -40,9 +60,12 @@ export function useActivityLogActions () {
     activityLog.value = activityLog.value.filter(
       entry => now.getTime() - entry.timestamp.getTime() < retentionMs
     )
+
+    persistActivityLog()
   }
 
   return {
+    initializeActivityLog,
     addActivity,
     clearActivityLog,
     cleanupExpiredEntries,

--- a/store/activityLog/getters.ts
+++ b/store/activityLog/getters.ts
@@ -5,7 +5,16 @@ export function useActivityLogGetters () {
   const { activityLog } = useActivityLogState()
 
   /**
-   * Get the most recent activity log entry
+   * Get activities for a specific date (YYYY-MM-DD)
+   */
+  const activitiesByDate = computed(() => {
+    return (date: string) => {
+      return activityLog.value.filter(entry => entry.date === date)
+    }
+  })
+
+  /**
+   * Get the most recent activity (across all dates)
    */
   const latestActivity = computed<ActivityLogEntry | null>(() => {
     if (activityLog.value.length === 0) {
@@ -88,6 +97,7 @@ export function useActivityLogGetters () {
   })
 
   return {
+    activitiesByDate,
     latestActivity,
     allActivities,
     timeSinceLastActivity,

--- a/store/activityLog/state.ts
+++ b/store/activityLog/state.ts
@@ -4,7 +4,9 @@ import type { ActivityLogEntry } from './type'
 const MAX_LOG_ENTRIES = 100
 
 /** Number of days to keep log entries */
-const LOG_RETENTION_DAYS = 3
+const LOG_RETENTION_DAYS = 7
+
+const STORAGE_KEY = 'activityLog:v1'
 
 const activityLog = ref<ActivityLogEntry[]>([])
 
@@ -26,4 +28,42 @@ export function getMaxLogEntries () {
 
 export function getLogRetentionDays () {
   return LOG_RETENTION_DAYS
+}
+
+export function hydrateActivityLogFromStorage () {
+  if (!process.client) {
+    return
+  }
+
+  const stored = localStorage.getItem(STORAGE_KEY)
+  if (!stored) {
+    return
+  }
+
+  try {
+    const parsed: Array<Omit<ActivityLogEntry, 'timestamp'> & { timestamp: string }> = JSON.parse(stored)
+    const hydrated = parsed
+      .map(entry => ({ ...entry, timestamp: new Date(entry.timestamp) }))
+      .filter(entry => !Number.isNaN(entry.timestamp.getTime()))
+
+    activityLog.value = hydrated
+
+    const maxId = hydrated.reduce((acc, entry) => Math.max(acc, entry.id), 0)
+    nextId = maxId + 1
+  } catch {
+    localStorage.removeItem(STORAGE_KEY)
+  }
+}
+
+export function persistActivityLog () {
+  if (!process.client) {
+    return
+  }
+
+  const serialized = activityLog.value.map(entry => ({
+    ...entry,
+    timestamp: entry.timestamp.toISOString(),
+  }))
+
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(serialized))
 }

--- a/store/activityLog/test.spec.ts
+++ b/store/activityLog/test.spec.ts
@@ -147,8 +147,8 @@ describe('ActivityLog Store', () => {
       const recent = new Date(now.getTime() - 24 * 60 * 60 * 1000)
 
       const payload = [
-        { id: 1, type: 'plus', drinkName: '古い', date: '2024-01-01', timestamp: expired.toISOString() },
-        { id: 5, type: 'minus', drinkName: '新しい', date: '2024-01-15', timestamp: recent.toISOString() },
+        { id: 1, type: 'plus', drinkName: '古い', drinkLabelName: null, date: '2024-01-01', timestamp: expired.toISOString() },
+        { id: 5, type: 'minus', drinkName: '新しい', drinkLabelName: null, date: '2024-01-15', timestamp: recent.toISOString() },
       ]
 
       localStorage.setItem('activityLog:v1', JSON.stringify(payload))

--- a/store/activityLog/test.spec.ts
+++ b/store/activityLog/test.spec.ts
@@ -5,12 +5,36 @@ import { setActivePinia, createPinia } from 'pinia'
 describe('ActivityLog Store', () => {
   let store: ReturnType<typeof import('./index').useActivityLogStore>
 
+  const createLocalStorageMock = (): Storage => {
+    const storage: Record<string, string> = {}
+    return {
+      get length () {
+        return Object.keys(storage).length
+      },
+      clear: vi.fn(() => {
+        Object.keys(storage).forEach(key => delete storage[key])
+      }),
+      getItem: vi.fn((key: string) => (key in storage ? storage[key] : null)),
+      key: vi.fn((index: number) => Object.keys(storage)[index] ?? null),
+      removeItem: vi.fn((key: string) => {
+        delete storage[key]
+      }),
+      setItem: vi.fn((key: string, value: string) => {
+        storage[key] = value
+      }),
+    }
+  }
+
   beforeEach(async () => {
     // creates a fresh pinia and makes it active
     setActivePinia(createPinia())
 
     // Reset the module to get fresh state
     vi.resetModules()
+
+    // Nuxt runtime flag for client-side only APIs
+    ;(process as any).client = true
+    globalThis.localStorage = createLocalStorageMock()
 
     const { useActivityLogStore } = await import('./index')
     store = useActivityLogStore()
@@ -109,6 +133,31 @@ describe('ActivityLog Store', () => {
     it('returns true when there are recent activities', () => {
       store.addActivity('plus', 'ビール')
       expect(store.hasRecentActivities).toBe(true)
+    })
+  })
+
+  describe('initializeActivityLog', () => {
+    it('hydrates from localStorage, removes expired entries, and keeps next id', () => {
+      const now = new Date()
+      const expired = new Date(now.getTime() - 8 * 24 * 60 * 60 * 1000)
+      const recent = new Date(now.getTime() - 24 * 60 * 60 * 1000)
+
+      const payload = [
+        { id: 1, type: 'plus', drinkName: '古い', timestamp: expired.toISOString() },
+        { id: 5, type: 'minus', drinkName: '新しい', timestamp: recent.toISOString() },
+      ]
+
+      localStorage.setItem('activityLog:v1', JSON.stringify(payload))
+
+      store.initializeActivityLog()
+
+      expect(store.activityLog.length).toBe(1)
+      expect(store.activityLog[0].drinkName).toBe('新しい')
+      expect(store.activityLog[0].timestamp).toBeInstanceOf(Date)
+
+      store.addActivity('plus', '追加')
+      expect(store.activityLog[0].id).toBe(6)
+      expect(localStorage.getItem('activityLog:v1')).not.toBeNull()
     })
   })
 })

--- a/store/activityLog/test.spec.ts
+++ b/store/activityLog/test.spec.ts
@@ -44,25 +44,27 @@ describe('ActivityLog Store', () => {
 
   describe('addActivity', () => {
     it('adds a plus activity to the log', () => {
-      store.addActivity('plus', 'ビール')
+      store.addActivity('plus', 'ビール', 'アルコール')
 
       expect(store.activityLog.length).toBe(1)
       expect(store.activityLog[0].type).toBe('plus')
       expect(store.activityLog[0].drinkName).toBe('ビール')
+      expect(store.activityLog[0].drinkLabelName).toBe('アルコール')
       expect(store.activityLog[0].timestamp).toBeInstanceOf(Date)
     })
 
     it('adds a minus activity to the log', () => {
-      store.addActivity('minus', 'ハイボール')
+      store.addActivity('minus', 'ハイボール', 'アルコール')
 
       expect(store.activityLog.length).toBe(1)
       expect(store.activityLog[0].type).toBe('minus')
       expect(store.activityLog[0].drinkName).toBe('ハイボール')
+      expect(store.activityLog[0].drinkLabelName).toBe('アルコール')
     })
 
     it('adds new activities at the beginning (newest first)', () => {
-      store.addActivity('plus', 'ビール')
-      store.addActivity('plus', 'ハイボール')
+      store.addActivity('plus', 'ビール', 'アルコール')
+      store.addActivity('plus', 'ハイボール', 'アルコール')
 
       expect(store.activityLog.length).toBe(2)
       expect(store.activityLog[0].drinkName).toBe('ハイボール')
@@ -76,8 +78,8 @@ describe('ActivityLog Store', () => {
     })
 
     it('returns the most recent activity', () => {
-      store.addActivity('plus', 'ビール')
-      store.addActivity('minus', 'ハイボール')
+      store.addActivity('plus', 'ビール', 'アルコール')
+      store.addActivity('minus', 'ハイボール', 'アルコール')
 
       expect(store.latestActivity?.drinkName).toBe('ハイボール')
       expect(store.latestActivity?.type).toBe('minus')
@@ -90,9 +92,9 @@ describe('ActivityLog Store', () => {
     })
 
     it('returns all activities sorted by timestamp (newest first)', () => {
-      store.addActivity('plus', 'ビール')
-      store.addActivity('minus', 'ハイボール')
-      store.addActivity('plus', 'ワイン')
+      store.addActivity('plus', 'ビール', 'アルコール')
+      store.addActivity('minus', 'ハイボール', 'アルコール')
+      store.addActivity('plus', 'ワイン', 'アルコール')
 
       expect(store.allActivities.length).toBe(3)
       expect(store.allActivities[0].drinkName).toBe('ワイン')
@@ -107,7 +109,7 @@ describe('ActivityLog Store', () => {
     })
 
     it('returns the time since the last activity', () => {
-      store.addActivity('plus', 'ビール')
+      store.addActivity('plus', 'ビール', 'アルコール')
       // The activity was just added, so the time should be very short
       expect(store.timeSinceLastActivity).toBe('0')
       expect(store.timeSinceLastActivityUnit).toBe('minutes')
@@ -116,8 +118,8 @@ describe('ActivityLog Store', () => {
 
   describe('clearActivityLog', () => {
     it('clears all activities', () => {
-      store.addActivity('plus', 'ビール')
-      store.addActivity('minus', 'ハイボール')
+      store.addActivity('plus', 'ビール', 'アルコール')
+      store.addActivity('minus', 'ハイボール', 'アルコール')
 
       store.clearActivityLog()
 
@@ -131,7 +133,7 @@ describe('ActivityLog Store', () => {
     })
 
     it('returns true when there are recent activities', () => {
-      store.addActivity('plus', 'ビール')
+      store.addActivity('plus', 'ビール', 'アルコール')
       expect(store.hasRecentActivities).toBe(true)
     })
   })

--- a/store/activityLog/test.spec.ts
+++ b/store/activityLog/test.spec.ts
@@ -44,27 +44,29 @@ describe('ActivityLog Store', () => {
 
   describe('addActivity', () => {
     it('adds a plus activity to the log', () => {
-      store.addActivity('plus', 'ビール', 'アルコール')
+      store.addActivity('plus', 'ビール', 'アルコール', '2024-01-15')
 
       expect(store.activityLog.length).toBe(1)
       expect(store.activityLog[0].type).toBe('plus')
       expect(store.activityLog[0].drinkName).toBe('ビール')
       expect(store.activityLog[0].drinkLabelName).toBe('アルコール')
+      expect(store.activityLog[0].date).toBe('2024-01-15')
       expect(store.activityLog[0].timestamp).toBeInstanceOf(Date)
     })
 
     it('adds a minus activity to the log', () => {
-      store.addActivity('minus', 'ハイボール', 'アルコール')
+      store.addActivity('minus', 'ハイボール', 'アルコール', '2024-01-15')
 
       expect(store.activityLog.length).toBe(1)
       expect(store.activityLog[0].type).toBe('minus')
       expect(store.activityLog[0].drinkName).toBe('ハイボール')
       expect(store.activityLog[0].drinkLabelName).toBe('アルコール')
+      expect(store.activityLog[0].date).toBe('2024-01-15')
     })
 
     it('adds new activities at the beginning (newest first)', () => {
-      store.addActivity('plus', 'ビール', 'アルコール')
-      store.addActivity('plus', 'ハイボール', 'アルコール')
+      store.addActivity('plus', 'ビール', 'アルコール', '2024-01-15')
+      store.addActivity('plus', 'ハイボール', 'アルコール', '2024-01-15')
 
       expect(store.activityLog.length).toBe(2)
       expect(store.activityLog[0].drinkName).toBe('ハイボール')
@@ -78,8 +80,8 @@ describe('ActivityLog Store', () => {
     })
 
     it('returns the most recent activity', () => {
-      store.addActivity('plus', 'ビール', 'アルコール')
-      store.addActivity('minus', 'ハイボール', 'アルコール')
+      store.addActivity('plus', 'ビール', 'アルコール', '2024-01-15')
+      store.addActivity('minus', 'ハイボール', 'アルコール', '2024-01-16')
 
       expect(store.latestActivity?.drinkName).toBe('ハイボール')
       expect(store.latestActivity?.type).toBe('minus')
@@ -92,9 +94,9 @@ describe('ActivityLog Store', () => {
     })
 
     it('returns all activities sorted by timestamp (newest first)', () => {
-      store.addActivity('plus', 'ビール', 'アルコール')
-      store.addActivity('minus', 'ハイボール', 'アルコール')
-      store.addActivity('plus', 'ワイン', 'アルコール')
+      store.addActivity('plus', 'ビール', 'アルコール', '2024-01-15')
+      store.addActivity('minus', 'ハイボール', 'アルコール', '2024-01-15')
+      store.addActivity('plus', 'ワイン', 'アルコール', '2024-01-16')
 
       expect(store.allActivities.length).toBe(3)
       expect(store.allActivities[0].drinkName).toBe('ワイン')
@@ -109,7 +111,7 @@ describe('ActivityLog Store', () => {
     })
 
     it('returns the time since the last activity', () => {
-      store.addActivity('plus', 'ビール', 'アルコール')
+      store.addActivity('plus', 'ビール', 'アルコール', '2024-01-15')
       // The activity was just added, so the time should be very short
       expect(store.timeSinceLastActivity).toBe('0')
       expect(store.timeSinceLastActivityUnit).toBe('minutes')
@@ -118,8 +120,8 @@ describe('ActivityLog Store', () => {
 
   describe('clearActivityLog', () => {
     it('clears all activities', () => {
-      store.addActivity('plus', 'ビール', 'アルコール')
-      store.addActivity('minus', 'ハイボール', 'アルコール')
+      store.addActivity('plus', 'ビール', 'アルコール', '2024-01-15')
+      store.addActivity('minus', 'ハイボール', 'アルコール', '2024-01-15')
 
       store.clearActivityLog()
 
@@ -133,7 +135,7 @@ describe('ActivityLog Store', () => {
     })
 
     it('returns true when there are recent activities', () => {
-      store.addActivity('plus', 'ビール', 'アルコール')
+      store.addActivity('plus', 'ビール', 'アルコール', '2024-01-15')
       expect(store.hasRecentActivities).toBe(true)
     })
   })
@@ -145,8 +147,8 @@ describe('ActivityLog Store', () => {
       const recent = new Date(now.getTime() - 24 * 60 * 60 * 1000)
 
       const payload = [
-        { id: 1, type: 'plus', drinkName: '古い', timestamp: expired.toISOString() },
-        { id: 5, type: 'minus', drinkName: '新しい', timestamp: recent.toISOString() },
+        { id: 1, type: 'plus', drinkName: '古い', date: '2024-01-01', timestamp: expired.toISOString() },
+        { id: 5, type: 'minus', drinkName: '新しい', date: '2024-01-15', timestamp: recent.toISOString() },
       ]
 
       localStorage.setItem('activityLog:v1', JSON.stringify(payload))
@@ -155,11 +157,29 @@ describe('ActivityLog Store', () => {
 
       expect(store.activityLog.length).toBe(1)
       expect(store.activityLog[0].drinkName).toBe('新しい')
+      expect(store.activityLog[0].date).toBe('2024-01-15')
       expect(store.activityLog[0].timestamp).toBeInstanceOf(Date)
 
-      store.addActivity('plus', '追加')
+      store.addActivity('plus', '追加', null, '2024-01-15')
       expect(store.activityLog[0].id).toBe(6)
       expect(localStorage.getItem('activityLog:v1')).not.toBeNull()
+    })
+  })
+
+  describe('activitiesByDate', () => {
+    it('filters activities by date', () => {
+      store.addActivity('plus', 'ビール', 'アルコール', '2024-01-15')
+      store.addActivity('minus', 'ハイボール', 'アルコール', '2024-01-16')
+      store.addActivity('plus', 'ワイン', 'アルコール', '2024-01-15')
+
+      const jan15 = store.activitiesByDate('2024-01-15')
+      expect(jan15.length).toBe(2)
+      expect(jan15[0].drinkName).toBe('ワイン')
+      expect(jan15[1].drinkName).toBe('ビール')
+
+      const jan16 = store.activitiesByDate('2024-01-16')
+      expect(jan16.length).toBe(1)
+      expect(jan16[0].drinkName).toBe('ハイボール')
     })
   })
 })

--- a/store/activityLog/type.ts
+++ b/store/activityLog/type.ts
@@ -8,6 +8,8 @@ export interface ActivityLogEntry {
   type: 'plus' | 'minus'
   /** Name of the drink */
   drinkName: string
+  /** Name of the drink label */
+  drinkLabelName: string | null
   /** Timestamp of the operation */
   timestamp: Date
 }

--- a/store/activityLog/type.ts
+++ b/store/activityLog/type.ts
@@ -10,6 +10,8 @@ export interface ActivityLogEntry {
   drinkName: string
   /** Name of the drink label */
   drinkLabelName: string | null
+  /** Date of the operation (YYYY-MM-DD) */
+  date: string
   /** Timestamp of the operation */
   timestamp: Date
 }

--- a/store/pages/index/actions.ts
+++ b/store/pages/index/actions.ts
@@ -103,9 +103,9 @@ export function useIndexActions () {
     numberOfDrink!.count++
     drinkCountForDay.value++
 
-    // Log the activity with label name
+    // Log the activity with label name and date
     const labelWithDrink = labelsWithDrinks.value.find(lwd => lwd.id === numberOfDrink!.drinkLabelId)
-    addActivity('plus', numberOfDrink!.name, labelWithDrink?.name ?? null)
+    addActivity('plus', numberOfDrink!.name, labelWithDrink?.name ?? null, date.value)
   }
 
   const minus = async (drinkId: number, drinkCounterId: number) => {
@@ -123,9 +123,9 @@ export function useIndexActions () {
     numberOfDrink!.count--
     drinkCountForDay.value--
 
-    // Log the activity with label name
+    // Log the activity with label name and date
     const labelWithDrink = labelsWithDrinks.value.find(lwd => lwd.id === numberOfDrink!.drinkLabelId)
-    addActivity('minus', numberOfDrink!.name, labelWithDrink?.name ?? null)
+    addActivity('minus', numberOfDrink!.name, labelWithDrink?.name ?? null, date.value)
   }
 
   const updateDefaultDrink = (labelId: number, drinkId: number) => {

--- a/store/pages/index/actions.ts
+++ b/store/pages/index/actions.ts
@@ -103,8 +103,9 @@ export function useIndexActions () {
     numberOfDrink!.count++
     drinkCountForDay.value++
 
-    // Log the activity
-    addActivity('plus', numberOfDrink!.name)
+    // Log the activity with label name
+    const labelWithDrink = labelsWithDrinks.value.find(lwd => lwd.id === numberOfDrink!.drinkLabelId)
+    addActivity('plus', numberOfDrink!.name, labelWithDrink?.name ?? null)
   }
 
   const minus = async (drinkId: number, drinkCounterId: number) => {
@@ -122,8 +123,9 @@ export function useIndexActions () {
     numberOfDrink!.count--
     drinkCountForDay.value--
 
-    // Log the activity
-    addActivity('minus', numberOfDrink!.name)
+    // Log the activity with label name
+    const labelWithDrink = labelsWithDrinks.value.find(lwd => lwd.id === numberOfDrink!.drinkLabelId)
+    addActivity('minus', numberOfDrink!.name, labelWithDrink?.name ?? null)
   }
 
   const updateDefaultDrink = (labelId: number, drinkId: number) => {


### PR DESCRIPTION
show #310 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 日付単位で絞り込めるアクティビティログ表示を追加しました
  * ドリンクのラベル名を含む詳細表示に対応しました
  * アクティビティをローカルに保存し、復元する仕組みを追加しました

* **改善**
  * ログ保持期間を3日から7日に延長しました
  * 期限切れデータの自動削除と永続化の同期を追加しました
  * ログ表示コンポーネントが表示日を受け取るようになりました

* **テスト**
  * 復元・永続化と日付絞り込みのテストを追加しました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->